### PR TITLE
Fix for Error 404 on manifest.json

### DIFF
--- a/src/util/util.cr
+++ b/src/util/util.cr
@@ -1,7 +1,7 @@
 IMGS_PER_PAGE            = 5
 ENTRIES_IN_HOME_SECTIONS = 8
 UPLOAD_URL_PREFIX        = "/uploads"
-STATIC_DIRS              = %w(/css /js /img /webfonts /favicon.ico /robots.txt)
+STATIC_DIRS              = %w(/css /js /img /webfonts /favicon.ico /robots.txt /manifest.json)
 SUPPORTED_FILE_EXTNAMES  = [".zip", ".cbz", ".rar", ".cbr"]
 SUPPORTED_IMG_TYPES      = %w(
   image/jpeg

--- a/src/util/util.cr
+++ b/src/util/util.cr
@@ -1,9 +1,10 @@
 IMGS_PER_PAGE            = 5
 ENTRIES_IN_HOME_SECTIONS = 8
 UPLOAD_URL_PREFIX        = "/uploads"
-STATIC_DIRS              = %w(/css /js /img /webfonts /favicon.ico /robots.txt /manifest.json)
-SUPPORTED_FILE_EXTNAMES  = [".zip", ".cbz", ".rar", ".cbr"]
-SUPPORTED_IMG_TYPES      = %w(
+STATIC_DIRS              = %w(/css /js /img /webfonts /favicon.ico /robots.txt
+  /manifest.json)
+SUPPORTED_FILE_EXTNAMES = [".zip", ".cbz", ".rar", ".cbr"]
+SUPPORTED_IMG_TYPES     = %w(
   image/jpeg
   image/png
   image/webp


### PR DESCRIPTION
Loading `manifest.json` would result in an Error 404, which prevented Mango from being added to the homescreen as a fullscreen web app. Fixed that by adding `/manifest.json` to the static files.