### PR TITLE
Synology Webstation seems to need this

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ WORKDIR /
 
 COPY --from=builder /Mango/mango /usr/local/bin/mango
 
+EXPOSE 9000
+
 CMD ["/usr/local/bin/mango"]


### PR DESCRIPTION
Not sure if it's just this though still testing.

What I'm expecting to see when I build the image:
![image](https://github.com/getmango/Mango/assets/111667/7b10ee81-f205-4670-ba34-a476f84af10a)

What I get. (Same image, mango is running but doesn't get listed.)